### PR TITLE
Add CRDNN backbone and training coverage

### DIFF
--- a/astfnet/cli/train.py
+++ b/astfnet/cli/train.py
@@ -68,7 +68,6 @@ def main() -> None:
         log_normalize_astf=config.get("log_normalize_astf", True),
         log_normalize_input=config.get("log_normalize_input", True),
         augmentation_params=augmentation_params,
-        model_name=config.get("model_name", ""),
     )
 
     # Build optimizer and scheduler factories from config

--- a/astfnet/data_io/datamodule.py
+++ b/astfnet/data_io/datamodule.py
@@ -143,7 +143,7 @@ class SeismicDataModule(pl.LightningDataModule):
             shuffle=True,
             pin_memory=True,
             drop_last=True,
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
 
     def val_dataloader(self) -> DataLoader:

--- a/astfnet/models/backbone.py
+++ b/astfnet/models/backbone.py
@@ -99,6 +99,7 @@ def _build_from_config(cls: Callable[..., nn.Module], config: Dict[str, Any]) ->
 def _ensure_registrations() -> None:
     """Import backbone modules so ``@register_backbone`` decorators run."""
     import astfnet.models.cnn  # noqa: F401
+    import astfnet.models.crdnn  # noqa: F401
     import astfnet.models.transformer  # noqa: F401
     import astfnet.models.unet1d  # noqa: F401
 

--- a/astfnet/models/crdnn.py
+++ b/astfnet/models/crdnn.py
@@ -1,0 +1,159 @@
+"""CRDNN backbone models for ASTF-net."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+import torch.nn as nn
+
+from astfnet.models.backbone import register_backbone
+from astfnet.models.rnn import RNNFactory
+
+
+class ConvBlock1D(nn.Module):
+    """Apply a Conv1d, BatchNorm1d, ReLU, pooling, and dropout block."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        pool_size: int,
+        dropout: float,
+    ) -> None:
+        """Initialize a convolutional block."""
+        super().__init__()
+        padding = kernel_size // 2
+        self.block = nn.Sequential(
+            nn.Conv1d(in_channels, out_channels, kernel_size=kernel_size, padding=padding),
+            nn.BatchNorm1d(out_channels),
+            nn.ReLU(),
+            nn.MaxPool1d(kernel_size=pool_size),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the convolutional block."""
+        return self.block(x)
+
+
+@register_backbone("crdnn")
+class CRDNN(nn.Module):
+    """Convolutional recurrent DNN backbone for ASTF prediction.
+
+    This follows the same high-level structure as SpeechBrain's CRDNN:
+    convolutional feature extraction, recurrent sequence modeling, and a dense
+    regression head. The implementation is adapted to ASTF-net's 1D waveform
+    inputs, where target waveform and EGF are treated as input channels.
+
+    Args:
+        in_channels: Number of input waveform channels. Must be 2 because
+            ``forward`` receives target waveform and EGF as separate inputs.
+        output_length: Length of the predicted ASTF sequence.
+        cnn_channels: Output channels for each convolutional block.
+        cnn_kernel_size: Kernel size used by each convolutional block.
+        cnn_pool_size: Pooling size used by each convolutional block.
+        rnn_name: Recurrent layer type, either ``"GRU"`` or ``"LSTM"``.
+        rnn_hidden_size: Number of hidden units per recurrent direction.
+        rnn_layers: Number of recurrent layers.
+        rnn_bidirectional: Whether to use bidirectional recurrence.
+        dnn_hidden_size: Hidden size of dense regression blocks.
+        dnn_layers: Number of dense blocks before the output layer.
+        dropout: Dropout probability used in CNN, RNN, and DNN blocks.
+        rnn_factory: Optional preconfigured RNN factory. When supplied, it
+            takes precedence over the ``rnn_*`` arguments.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 2,
+        output_length: int = 501,
+        cnn_channels: Sequence[int] = (64, 128),
+        cnn_kernel_size: int = 5,
+        cnn_pool_size: int = 2,
+        rnn_name: str = "GRU",
+        rnn_hidden_size: int = 128,
+        rnn_layers: int = 2,
+        rnn_bidirectional: bool = True,
+        dnn_hidden_size: int = 256,
+        dnn_layers: int = 1,
+        dropout: float = 0.1,
+        rnn_factory: Optional[RNNFactory] = None,
+    ) -> None:
+        """Initialize the CRDNN backbone."""
+        super().__init__()
+        if in_channels != 2:
+            raise ValueError(f"CRDNN expects exactly 2 input channels: target waveform and EGF; got {in_channels!r}.")
+        if output_length <= 0:
+            raise ValueError(f"output_length must be positive, got {output_length!r}.")
+        if cnn_kernel_size <= 0:
+            raise ValueError(f"cnn_kernel_size must be positive, got {cnn_kernel_size!r}.")
+        if cnn_pool_size <= 0:
+            raise ValueError(f"cnn_pool_size must be positive, got {cnn_pool_size!r}.")
+        if dnn_layers < 0:
+            raise ValueError(f"dnn_layers must be non-negative, got {dnn_layers!r}.")
+
+        channels = list(cnn_channels)
+        if not channels:
+            raise ValueError("cnn_channels must contain at least one channel size.")
+        if any(channel <= 0 for channel in channels):
+            raise ValueError("cnn_channels must contain only positive channel sizes.")
+
+        cnn_blocks = []
+        prev_channels = in_channels
+        for channels_out in channels:
+            cnn_blocks.append(
+                ConvBlock1D(
+                    in_channels=prev_channels,
+                    out_channels=channels_out,
+                    kernel_size=cnn_kernel_size,
+                    pool_size=cnn_pool_size,
+                    dropout=dropout,
+                )
+            )
+            prev_channels = channels_out
+        self.cnn = nn.Sequential(*cnn_blocks)
+
+        if rnn_factory is None:
+            rnn_factory = RNNFactory(
+                name=rnn_name,
+                hidden_size=rnn_hidden_size,
+                num_layers=rnn_layers,
+                bidirectional=rnn_bidirectional,
+                dropout=dropout,
+            )
+        self.rnn_factory = rnn_factory
+        self.rnn = self.rnn_factory.build(input_size=prev_channels)
+
+        dnn_blocks = []
+        input_features = self.rnn_factory.output_size
+        for _ in range(dnn_layers):
+            dnn_blocks.extend(
+                [
+                    nn.Linear(input_features, dnn_hidden_size),
+                    nn.ReLU(),
+                    nn.Dropout(dropout),
+                ]
+            )
+            input_features = dnn_hidden_size
+
+        dnn_blocks.extend([nn.Linear(input_features, output_length), nn.Softplus()])
+        self.regressor = nn.Sequential(*dnn_blocks)
+
+    def forward(self, target_waveform: torch.Tensor, egf: torch.Tensor) -> torch.Tensor:
+        """Run a forward pass.
+
+        Args:
+            target_waveform: Target waveform with shape ``(batch_size, seq_len)``.
+            egf: Empirical Green's function with shape ``(batch_size, seq_len)``.
+
+        Returns:
+            Predicted ASTF with shape ``(batch_size, output_length)``.
+        """
+        x = torch.stack([target_waveform, egf], dim=1)
+        x = self.cnn(x)
+        x = x.permute(0, 2, 1)
+        x, _ = self.rnn(x)
+        x = x.mean(dim=1)
+        return self.regressor(x)

--- a/astfnet/models/rnn.py
+++ b/astfnet/models/rnn.py
@@ -1,0 +1,74 @@
+"""RNN factory utilities for ASTF-net models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Type
+
+import torch.nn as nn
+
+RNN_REGISTRY: Dict[str, Type[nn.RNNBase]] = {
+    "GRU": nn.GRU,
+    "LSTM": nn.LSTM,
+}
+
+
+@dataclass
+class RNNFactory:
+    """Factory for constructing recurrent layers.
+
+    Args:
+        name: Recurrent layer type. Supported values are ``"GRU"`` and
+            ``"LSTM"``.
+        hidden_size: Number of hidden units per recurrent direction.
+        num_layers: Number of stacked recurrent layers.
+        bidirectional: Whether to use bidirectional recurrence.
+        dropout: Dropout between recurrent layers. PyTorch only applies this
+            when ``num_layers > 1``.
+    """
+
+    name: str = "GRU"
+    hidden_size: int = 128
+    num_layers: int = 2
+    bidirectional: bool = True
+    dropout: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate factory settings."""
+        self.name = self.name.upper()
+        if self.name not in RNN_REGISTRY:
+            raise ValueError(f"Unknown RNN {self.name!r}. Supported: {list(RNN_REGISTRY)}.")
+        if self.hidden_size <= 0:
+            raise ValueError(f"hidden_size must be positive, got {self.hidden_size!r}.")
+        if self.num_layers <= 0:
+            raise ValueError(f"num_layers must be positive, got {self.num_layers!r}.")
+        if self.dropout < 0:
+            raise ValueError(f"dropout must be non-negative, got {self.dropout!r}.")
+
+    @property
+    def output_size(self) -> int:
+        """Return the feature size produced by the recurrent layer."""
+        directions = 2 if self.bidirectional else 1
+        return self.hidden_size * directions
+
+    def build(self, input_size: int) -> nn.RNNBase:
+        """Instantiate the configured recurrent layer.
+
+        Args:
+            input_size: Number of input features per time step.
+
+        Returns:
+            A configured PyTorch recurrent layer.
+        """
+        if input_size <= 0:
+            raise ValueError(f"input_size must be positive, got {input_size!r}.")
+
+        rnn_dropout = self.dropout if self.num_layers > 1 else 0.0
+        return RNN_REGISTRY[self.name](
+            input_size=input_size,
+            hidden_size=self.hidden_size,
+            num_layers=self.num_layers,
+            batch_first=True,
+            bidirectional=self.bidirectional,
+            dropout=rnn_dropout,
+        )

--- a/config/config-crdnn.yaml
+++ b/config/config-crdnn.yaml
@@ -1,0 +1,73 @@
+# ASTF-net CRDNN training configuration
+
+tb_output_dir: ".sdev/output/"
+tb_exp_name: "crdnn_dev"
+
+# Dataset — data_path must be supplied via --data CLI argument
+batch_size: 4096
+num_workers: 16
+log_normalize_astf: false
+log_normalize_input: true
+
+# Data augmentations
+augmentations:
+  - AddRandomNoise:
+      noise_level: 0.1
+  - DropRegion:
+      max_drop_length: 10
+  - AddTrend:
+      min_deg: -1
+      max_deg: 1
+  - RandomShift:
+      max_shift: 10
+
+max_augmentations: 1
+
+# Model hyperparameters
+model_name: "crdnn"
+loss: "mse"
+max_epochs: 100
+device: "gpu"
+gpus: [0]
+
+# Data input and output
+in_channels: 2
+output_length: 256
+
+# CRDNN-specific
+cnn_channels: [64, 128]
+cnn_kernel_size: 5
+cnn_pool_size: 2
+rnn_name: "GRU"
+rnn_hidden_size: 128
+rnn_layers: 2
+rnn_bidirectional: true
+dnn_hidden_size: 256
+dnn_layers: 1
+dropout: 0.1
+
+# Optimizer — forwarded to OptimizerFactory.from_config()
+# Supported names: Adam, AdamW
+optimizer:
+  name: Adam
+  lr: 0.0001
+
+# Callbacks configuration
+callbacks:
+  early_stopping:
+    monitor: "val/loss_epoch"
+    mode: "min"
+    patience: 10
+    min_delta: 0.0
+    verbose: true
+  lr_scheduler:
+    name: ReduceLROnPlateau
+    monitor: "val/loss_epoch"
+    mode: "min"
+    factor: 0.5
+    patience: 10
+  model_checkpoint:
+    monitor: "val/loss_epoch"
+    mode: "min"
+    save_top_k: 1
+    filename: "best-{epoch:02d}-{val_loss_epoch:.4f}"

--- a/tests/test_crdnn.py
+++ b/tests/test_crdnn.py
@@ -1,0 +1,96 @@
+from typing import Any, Dict
+
+import pytest
+import torch
+
+from astfnet.models.base import ASTFModule
+from astfnet.models.crdnn import CRDNN
+from astfnet.models.rnn import RNNFactory
+
+BATCH_SIZE = 3
+SEQ_LEN = 256
+OUTPUT_LENGTH = 128
+
+
+@pytest.fixture
+def crdnn_config() -> Dict[str, Any]:
+    return {
+        "model_name": "crdnn",
+        "loss": "mse",
+        "in_channels": 2,
+        "output_length": OUTPUT_LENGTH,
+        "cnn_channels": [16, 32],
+        "cnn_kernel_size": 5,
+        "cnn_pool_size": 2,
+        "rnn_hidden_size": 24,
+        "rnn_layers": 1,
+        "rnn_bidirectional": True,
+        "dnn_hidden_size": 64,
+        "dnn_layers": 1,
+        "dropout": 0.0,
+    }
+
+
+@pytest.mark.parametrize("rnn_name", ["GRU", "LSTM", "gru", "lstm"])
+def test_rnn_factory_builds_supported_rnns(rnn_name: str) -> None:
+    factory = RNNFactory(name=rnn_name, hidden_size=16, num_layers=1, bidirectional=True)
+    rnn = factory.build(input_size=8)
+
+    assert factory.name == rnn_name.upper()
+    assert factory.output_size == 32
+    assert isinstance(rnn, (torch.nn.GRU, torch.nn.LSTM))
+
+
+def test_rnn_factory_rejects_unknown_rnn() -> None:
+    with pytest.raises(ValueError, match="Unknown RNN"):
+        RNNFactory(name="RNN")
+
+
+@pytest.mark.parametrize("rnn_name", ["GRU", "LSTM"])
+def test_crdnn_forward_shape(rnn_name: str, crdnn_config: Dict[str, Any]) -> None:
+    kwargs = {k: v for k, v in crdnn_config.items() if k not in {"model_name", "loss"}}
+    model = CRDNN(**{**kwargs, "rnn_name": rnn_name})
+    target = torch.randn(BATCH_SIZE, SEQ_LEN)
+    egf = torch.randn(BATCH_SIZE, SEQ_LEN)
+
+    out = model(target, egf)
+
+    assert out.shape == (BATCH_SIZE, OUTPUT_LENGTH)
+    assert (out >= 0).all()
+
+
+def test_crdnn_accepts_rnn_factory() -> None:
+    factory = RNNFactory(name="LSTM", hidden_size=12, num_layers=1, bidirectional=False)
+    model = CRDNN(
+        output_length=OUTPUT_LENGTH,
+        cnn_channels=[16],
+        rnn_factory=factory,
+        dnn_hidden_size=32,
+        dropout=0.0,
+    )
+
+    out = model(torch.randn(2, SEQ_LEN), torch.randn(2, SEQ_LEN))
+
+    assert out.shape == (2, OUTPUT_LENGTH)
+    assert isinstance(model.rnn, torch.nn.LSTM)
+
+
+@pytest.mark.parametrize("in_channels", [1, 3])
+def test_crdnn_rejects_non_two_channel_configs(in_channels: int) -> None:
+    with pytest.raises(ValueError, match="exactly 2 input channels"):
+        CRDNN(in_channels=in_channels)
+
+
+def test_astf_module_builds_crdnn_from_config(crdnn_config: Dict[str, Any]) -> None:
+    model = ASTFModule({**crdnn_config, "rnn_name": "GRU"})
+    batch = {
+        "target": torch.randn(BATCH_SIZE, SEQ_LEN),
+        "egf": torch.randn(BATCH_SIZE, SEQ_LEN),
+        "astf": torch.abs(torch.randn(BATCH_SIZE, OUTPUT_LENGTH)),
+    }
+
+    out = model(batch["target"], batch["egf"])
+    loss = model.training_step(batch, 0)
+
+    assert out.shape == (BATCH_SIZE, OUTPUT_LENGTH)
+    assert loss.requires_grad

--- a/tests/test_training_e2e.py
+++ b/tests/test_training_e2e.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+from typing import Any, Dict
+
+import h5py
+import numpy as np
+import pytest
+import pytorch_lightning as pl
+
+from astfnet.data_io.datamodule import SeismicDataModule
+from astfnet.models import ASTFModule
+from astfnet.models.optimizer import OptimizerFactory
+from astfnet.models.scheduler import SchedulerFactory
+
+SEQ_LEN = 256
+OUTPUT_LENGTH = 256
+
+
+def _write_dummy_hdf5(path: Path, n_samples: int = 4) -> None:
+    rng = np.random.default_rng(1234)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("target_waveforms", data=rng.normal(size=(n_samples, SEQ_LEN)).astype(np.float32))
+        f.create_dataset("egfs", data=rng.normal(size=(n_samples, SEQ_LEN)).astype(np.float32))
+        f.create_dataset("astfs", data=np.abs(rng.normal(size=(n_samples, OUTPUT_LENGTH))).astype(np.float32))
+
+
+def _base_train_config(model_name: str) -> Dict[str, Any]:
+    return {
+        "model_name": model_name,
+        "loss": "mse",
+        "batch_size": 2,
+        "num_workers": 0,
+        "log_normalize_astf": False,
+        "log_normalize_input": True,
+        "augmentations": [],
+        "max_augmentations": 0,
+        "max_epochs": 1,
+        "device": "cpu",
+        "gpus": 1,
+        "in_channels": 2,
+        "output_length": OUTPUT_LENGTH,
+        "optimizer": {
+            "name": "Adam",
+            "lr": 1e-3,
+        },
+        "callbacks": {
+            "lr_scheduler": {
+                "name": "ReduceLROnPlateau",
+                "monitor": "val/loss_epoch",
+                "mode": "min",
+                "factor": 0.5,
+                "patience": 1,
+            },
+        },
+    }
+
+
+def _model_train_config(model_name: str) -> Dict[str, Any]:
+    config = _base_train_config(model_name)
+    model_configs: Dict[str, Dict[str, Any]] = {
+        "simplecnn": {},
+        "transformer": {
+            "cnn_kernel_size": 16,
+            "cnn_stride": 16,
+            "d_model": 16,
+            "nhead": 2,
+            "num_encoder_layers": 1,
+            "dim_feedforward": 32,
+            "dropout": 0.0,
+        },
+        "unet1d": {
+            "dropout_shallow": 0.0,
+            "dropout_deep": 0.0,
+        },
+        "crdnn": {
+            "cnn_channels": [8, 16],
+            "cnn_kernel_size": 5,
+            "cnn_pool_size": 2,
+            "rnn_name": "GRU",
+            "rnn_hidden_size": 16,
+            "rnn_layers": 1,
+            "rnn_bidirectional": True,
+            "dnn_hidden_size": 32,
+            "dnn_layers": 1,
+            "dropout": 0.0,
+        },
+    }
+    config.update(model_configs[model_name])
+    return config
+
+
+@pytest.mark.parametrize("model_name", ["simplecnn", "transformer", "unet1d", "crdnn"])
+def test_train_py_style_fit_runs_one_training_step_for_implemented_models(tmp_path: Path, model_name: str) -> None:
+    train_hdf5_file = tmp_path / "train.h5"
+    val_hdf5_file = tmp_path / "val.h5"
+    test_hdf5_file = tmp_path / "test.h5"
+    for path in [train_hdf5_file, val_hdf5_file, test_hdf5_file]:
+        _write_dummy_hdf5(path)
+
+    config = _model_train_config(model_name)
+    augmentation_params = {
+        "augmentations": config.get("augmentations", config.get("data_augmentations", [])),
+        "max_augmentations": int(config.get("max_augmentations", 0)),
+    }
+    datamodule = SeismicDataModule(
+        train_hdf5_file=str(train_hdf5_file),
+        val_hdf5_file=str(val_hdf5_file),
+        test_hdf5_files=[str(test_hdf5_file)],
+        batch_size=config.get("batch_size", 32),
+        num_workers=config.get("num_workers", 2),
+        log_normalize_astf=config.get("log_normalize_astf", True),
+        log_normalize_input=config.get("log_normalize_input", True),
+        augmentation_params=augmentation_params,
+    )
+
+    optimizer_factory = OptimizerFactory.from_config(config)
+    scheduler_factory = SchedulerFactory.from_config(config)
+    model = ASTFModule(config, optimizer_factory=optimizer_factory, scheduler_factory=scheduler_factory)
+
+    trainer = pl.Trainer(
+        max_epochs=config["max_epochs"],
+        accelerator=config["device"],
+        devices=config["gpus"],
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        num_sanity_val_steps=0,
+    )
+
+    trainer.fit(model, datamodule=datamodule)
+
+    assert trainer.global_step == 1


### PR DESCRIPTION
## Summary
- Add a CRDNN backbone with configurable CNN, GRU/LSTM, and dense regression blocks.
- Register CRDNN in the backbone factory and add a CRDNN training config.
- Add CRDNN unit tests plus end-to-end Lightning training coverage for `simplecnn`, `transformer`, `unet1d`, and `crdnn`.
- Remove the unused `model_name` argument from `SeismicDataModule` construction in `train.py`.

## Validation
- `uv run pytest -q`